### PR TITLE
Disable default features from image crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ is-it-maintained-open-issues = { repository = "qnighy/libwebp-image-rs" }
 
 [dependencies]
 libwebp = "0.1.0"
-image = "0.23.12"
+image = { version = "0.23.12", default-features = false }
 
 [dev-dependencies]
 rand = "0.8.3"


### PR DESCRIPTION
By default, the image crate pulls in a number of encoders and decoders, which aren't needed here.  This doesn't prevent a user of this library from using them, but does allow them to control which of them get included.