### PR TITLE
expose quality parameter as part of public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ is-it-maintained-open-issues = { repository = "qnighy/libwebp-image-rs" }
 
 [dependencies]
 libwebp = "0.1.0"
-image = { version = "0.23.12", default-features = false }
+image = { version = "0.24.0", default-features = false }
 
 [dev-dependencies]
 rand = "0.8.3"


### PR DESCRIPTION
this was previously always set to 0.75, but in case library users might want to use custom values for quality_factor, so I am exposing that with this PR. If you don't like my formatting, I can change it back to use longer lines, but then the code won't be rustfmt-formatted anymore (which it was before).

Related question: I will definitely also need a way to losslessly encode; would like to know how you would like to see that exposed in the API. I would probably change the quality_factor to an `enum Compression { Lossless, Lossy(f32) }`, but am open to other options. I could also add that new API to this PR if you'd like.